### PR TITLE
Updated Helm version and change priority value for jobs

### DIFF
--- a/lib/application-stack.ts
+++ b/lib/application-stack.ts
@@ -258,7 +258,7 @@ export class ApplicationStack extends cdk.Stack {
       repository:
         'https://raw.githubusercontent.com/CloudVE/helm-charts/master/',
       namespace: namespace,
-      version: "5.8.0",
+      version: "5.9.0",
       timeout: cdk.Duration.minutes(10),
       values: {
         configs: {
@@ -376,6 +376,12 @@ export class ApplicationStack extends cdk.Stack {
         persistence: {
           storageClass: 'efs-sc',
           accessMode: 'ReadWriteMany',
+        },
+        // Value cannot be updated on exisiting deployment
+        jobs: {
+          priorityClass: {
+              value: 1000 // The k8s autoscaler only spins up new nodes up for priority larger than -10.
+            }
         },
       },
     });


### PR DESCRIPTION
*Issue #, if available:* #4

*Description of changes:*

Updated the helm version to incorporate latest change of the Galaxy Helm Chart, exposing the value for the priority class: https://github.com/galaxyproject/galaxy-helm/commit/adfda49ac7a7ca6c9598dd73a39c9feb99cef76b
Setting this value to 1000 by default. Kubernetes currently does not support the updating of the priority value for an existing priority class. Thus it is not configurable via `cdk.json`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
